### PR TITLE
Add type declares for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "android"
   ],
   "main": "src/index.js",
+  "types": "./src/index.d.ts",
   "files": [
     "src",
     "README.md"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,10 @@ export declare const DEFAULT_COLORS: string[];
 export declare const DEFAULT_EXPLOSION_SPEED: number;
 export declare const DEFAULT_FALL_SPEED: number;
 
-declare class Explosion extends React.PureComponent<ExplosionProps, ExplosionState> {}
+declare class Explosion extends React.PureComponent<ExplosionProps, ExplosionState> {
+  start: (resume?: boolean) => void;
+  resume: () => void;
+  stop: () => void;
+}
 
 export default Explosion;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface ExplosionProps {
+export interface ExplosionProps {
   count: number;
   origin: {
     x: number;
@@ -19,7 +19,7 @@ interface ExplosionProps {
   testID?: string;
 }
 
-interface ConfettiItem {
+export interface ConfettiItem {
   leftDelta: number;
   topDelta: number;
   swingDelta: number;
@@ -31,7 +31,7 @@ interface ConfettiItem {
   color: string;
 }
 
-interface ExplosionState {
+export interface ExplosionState {
   items: ConfettiItem[];
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+interface IExplosionProps {
+  count: number;
+  origin: {
+    x: number;
+    y: number
+  };
+  explosionSpeed?: number;
+  fallSpeed?: number;
+  colors?: string[];
+  fadeOut?: boolean;
+  autoStart?: boolean;
+  autoStartDelay?: number;
+  onAnimationStart?: () => void;
+  onAnimationResume?: () => void;
+  onAnimationStop?: () => void;
+  onAnimationEnd?: () => void;
+  testID?: string;
+}
+
+interface IConfettiItem {
+  leftDelta: number;
+  topDelta: number;
+  swingDelta: number;
+  speedDelta: {
+    rotateX: number;
+    rotateY: number;
+    rotateZ: number;
+  };
+  color: string;
+}
+
+interface IExplosionState {
+  items: IConfettiItem[];
+}
+
+export declare const TOP_MIN: number;
+export declare const DEFAULT_COLORS: string[];
+export declare const DEFAULT_EXPLOSION_SPEED: number;
+export declare const DEFAULT_FALL_SPEED: number;
+
+declare class Explosion extends React.PureComponent<IExplosionProps, IExplosionState> {}
+
+export default Explosion;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-interface IExplosionProps {
+interface ExplosionProps {
   count: number;
   origin: {
     x: number;
@@ -19,7 +19,7 @@ interface IExplosionProps {
   testID?: string;
 }
 
-interface IConfettiItem {
+interface ConfettiItem {
   leftDelta: number;
   topDelta: number;
   swingDelta: number;
@@ -31,8 +31,8 @@ interface IConfettiItem {
   color: string;
 }
 
-interface IExplosionState {
-  items: IConfettiItem[];
+interface ExplosionState {
+  items: ConfettiItem[];
 }
 
 export declare const TOP_MIN: number;
@@ -40,6 +40,6 @@ export declare const DEFAULT_COLORS: string[];
 export declare const DEFAULT_EXPLOSION_SPEED: number;
 export declare const DEFAULT_FALL_SPEED: number;
 
-declare class Explosion extends React.PureComponent<IExplosionProps, IExplosionState> {}
+declare class Explosion extends React.PureComponent<ExplosionProps, ExplosionState> {}
 
 export default Explosion;


### PR DESCRIPTION
# Description

This PR adds a new file `index.d.ts`, which contains typings for TypeScript. Related to #17.

### Result

- Enables autocompletions, type checking, etc. in TS environments.
- You may want to migrate the entire module with TS - if so, you can just reject this PR comfortably or use the declares until that update 😉

### Issue

https://github.com/VincentCATILLON/react-native-confetti-cannon/issues/17