### PR TITLE
feat(ui): non full-windowed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,17 @@ const MyComponent = () => (
 
 ## Props
 
-| Name             | Type                   | Description                                | Required | Default        |
-|------------------|------------------------|--------------------------------------------|----------|----------------|
-| count            | number                 | items count to display                     | required |                |
-| origin           | {x: number, y: number} | animation position origin                  | required |                |
-| explosionSpeed   | number                 | explosion duration (ms) from origin to top |          | 350            |
-| fallSpeed        | number                 | fall duration (ms) from top to bottom      |          | 3000           |
-| fadeOut          | boolean                | make the confettis disappear at the end    |          | false          |
-| colors           | string[]               | give your own colors to the confettis      |          | default colors |
-| autoStart        | boolean                | auto start the animation                   |          | true           |
-| autoStartDelay   | number                 | delay to wait before triggering animation  |          | 0              |
+| Name             | Type                            | Description                                | Required | Default                  |
+|------------------|---------------------------------|--------------------------------------------|----------|--------------------------|
+| count            | number                          | items count to display                     | required |                          |
+| origin           | {x: number, y: number}          | animation position origin                  | required |                          |
+| window           | {width: number, height: number} | width and height of the animation "window" |          | Dimensions.get('window') |
+| explosionSpeed   | number                          | explosion duration (ms) from origin to top |          | 350                      |
+| fallSpeed        | number                          | fall duration (ms) from top to bottom      |          | 3000                     |
+| fadeOut          | boolean                         | make the confettis disappear at the end    |          | false                    |
+| colors           | string[]                        | give your own colors to the confettis      |          | default colors           |
+| autoStart        | boolean                         | auto start the animation                   |          | true                     |
+| autoStartDelay   | number                          | delay to wait before triggering animation  |          | 0                        |
 
 ## Events
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,10 @@ export interface ExplosionProps {
     x: number;
     y: number
   };
+  window?: {
+    width: number,
+    height: number,
+  },
   explosionSpeed?: number;
   fallSpeed?: number;
   colors?: string[];

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,10 @@ type Props = {|
     x: number,
     y: number
   },
+  window?: {
+    width: number,
+    height: number,
+  },
   explosionSpeed?: number,
   fallSpeed?: number,
   colors?: Array<string>,
@@ -178,9 +182,9 @@ class Explosion extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { origin, fadeOut } = this.props;
+    const { origin, fadeOut, window } = this.props;
     const { items } = this.state;
-    const { height, width } = Dimensions.get('window');
+    const { height, width } = window ?? Dimensions.get('window');
 
     return (
       <React.Fragment>


### PR DESCRIPTION
# Description

Add support for non-fullscreen confetti. Useful if using a navbar, or any other component that obscures part of the screen. behaviour is backwards compatible (defaults to `Dimensions.get('window')`).

### Result

N/A

### Related issues

N/A
